### PR TITLE
stat_svc_client Add stats client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
   stats-db:
     image: postgres:16.1
     container_name: postgres-ewm-stats-db
+    environment:
+      POSTGRES_PASSWORD: password
     ports:
       - "6542:5432"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     container_name: stats-server
     ports:
       - "9090:9090"
+#    environment:
+#      - SPRING_DATASOURCE_URL=jdbc:postgresql://ewm-db:5432/ewm-stats
+#      - SPRING_DATASOURCE_USERNAME=stat
+#      - SPRING_DATASOURCE_PASSWORD=stat
 
   stats-db:
     image: postgres:16.1
@@ -15,3 +19,8 @@ services:
     build: main-service
     ports:
       - "8080:8080"
+#    environment:
+#      - CLIENT_URL=http://stats-server:9090
+#      - SPRING_DATASOURCE_URL=jdbc:postgresql://ewm-db:5432/ewm-main
+#      - SPRING_DATASOURCE_USERNAME=main
+#      - SPRING_DATASOURCE_PASSWORD=main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
 
   ewm-service:
     build: main-service
+    container_name: ewm-server
     ports:
       - "8080:8080"
 #    environment:

--- a/main-service/Dockerfile
+++ b/main-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+ENTRYPOINT ["java","-jar","/app/app.jar", "./src/main/java/ewm/MainApplication"]

--- a/main-service/Dockerfile
+++ b/main-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
-#COPY target/*.jar app.jar
-#ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/main-service/Dockerfile
+++ b/main-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
-COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+#COPY target/*.jar app.jar
+#ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -24,5 +24,36 @@
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>ewm.MainApplication</mainClass>
+                    <layout>JAR</layout>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>ewm.MainApplication</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/main-service/pom.xml
+++ b/main-service/pom.xml
@@ -3,10 +3,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ru.practicum</groupId>
+        <artifactId>explore-with-me</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
 
-    <groupId>ru.practicum</groupId>
     <artifactId>main-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/main-service/src/main/java/ewm/MainApplication.java
+++ b/main-service/src/main/java/ewm/MainApplication.java
@@ -1,0 +1,12 @@
+package ewm;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MainApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MainApplication.class, args);
+    }
+
+}

--- a/stats-service/pom.xml
+++ b/stats-service/pom.xml
@@ -13,7 +13,6 @@
     <artifactId>stats-service</artifactId>
     <packaging>pom</packaging>
 
-
     <modules>
         <module>stats-client</module>
         <module>stats-dto</module>

--- a/stats-service/stats-client/pom.xml
+++ b/stats-service/stats-client/pom.xml
@@ -4,9 +4,38 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>ru.practicum</groupId>
     <artifactId>stats-client</artifactId>
     <version>0.0.1-SNAPSHOT</version>
+
+    <parent>
+        <groupId>ru.practicum</groupId>
+        <artifactId>stats-service</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>ru.practicum</groupId>
+            <artifactId>stats-dto</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>false</optional>
+        </dependency>
+    </dependencies>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/stats-service/stats-client/src/main/java/client/StatsClient.java
+++ b/stats-service/stats-client/src/main/java/client/StatsClient.java
@@ -1,0 +1,18 @@
+package client;
+
+import ru.practicum.ewm.stats.dto.EndpointHitDto;
+import ru.practicum.ewm.stats.dto.ViewStatsDto;
+
+import java.util.List;
+
+public interface StatsClient {
+
+    void hit(EndpointHitDto endpointHit);
+
+    List<ViewStatsDto> getStats(
+            String start,
+            String end,
+            List<String> uris,
+            Boolean unique
+    );
+}

--- a/stats-service/stats-client/src/main/java/client/StatsClientImpl.java
+++ b/stats-service/stats-client/src/main/java/client/StatsClientImpl.java
@@ -22,7 +22,7 @@ public class StatsClientImpl implements StatsClient {
 
     public StatsClientImpl(
             RestTemplate restTemplate,
-            @Value("${stats.service.url:http://localhost:9090}") String baseUrl
+            @Value("${stats.service.url}") String baseUrl
     ) {
         this.restTemplate = restTemplate;
         this.baseUrl = baseUrl;

--- a/stats-service/stats-client/src/main/java/client/StatsClientImpl.java
+++ b/stats-service/stats-client/src/main/java/client/StatsClientImpl.java
@@ -1,0 +1,81 @@
+package client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import ru.practicum.ewm.stats.dto.EndpointHitDto;
+import ru.practicum.ewm.stats.dto.ViewStatsDto;
+
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class StatsClientImpl implements StatsClient {
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+
+    public StatsClientImpl(
+            RestTemplate restTemplate,
+            @Value("${stats.service.url:http://localhost:9090}") String baseUrl
+    ) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * POST /hit
+     */
+    @Override
+    public void hit(EndpointHitDto endpointHit) {
+        String url = UriComponentsBuilder
+                .fromHttpUrl(baseUrl)
+                .path("/hit")
+                .toUriString();
+
+        HttpEntity<EndpointHitDto> request = new HttpEntity<>(endpointHit);
+        restTemplate.postForEntity(url, request, Void.class);
+    }
+
+    /**
+     * GET /stats
+     */
+    @Override
+    public List<ViewStatsDto> getStats(
+            String start,
+            String end,
+            List<String> uris,
+            Boolean unique
+    ) {
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromHttpUrl(baseUrl)
+                .path("/stats")
+                .queryParam("start", start)
+                .queryParam("end", end);
+
+        if (uris != null && !uris.isEmpty()) {
+            uris.forEach(uri -> builder.queryParam("uris", uri));
+        }
+
+        if (unique != null) {
+            builder.queryParam("unique", unique);
+        }
+
+        ResponseEntity<List<ViewStatsDto>> response = restTemplate.exchange(
+                builder.build(true).toUri(),
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {
+                }
+        );
+
+        return response.getBody() != null
+                ? response.getBody()
+                : Collections.emptyList();
+    }
+}

--- a/stats-service/stats-client/src/main/resources/application.properties
+++ b/stats-service/stats-client/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+stats.service.url=http://localhost:9090

--- a/stats-service/stats-server/Dockerfile
+++ b/stats-service/stats-server/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+ENTRYPOINT ["java","-jar","/app/app.jar", "./src/main/java/ewm/StatsApplication"]

--- a/stats-service/stats-server/Dockerfile
+++ b/stats-service/stats-server/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
-#COPY target/*.jar app.jar
-#ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/stats-service/stats-server/Dockerfile
+++ b/stats-service/stats-server/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
-COPY target/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+#COPY target/*.jar app.jar
+#ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/stats-service/stats-server/pom.xml
+++ b/stats-service/stats-server/pom.xml
@@ -3,10 +3,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ru.practicum</groupId>
+        <artifactId>stats-service</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
 
-    <groupId>ru.practicum</groupId>
     <artifactId>stats-server</artifactId>
     <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>

--- a/stats-service/stats-server/pom.xml
+++ b/stats-service/stats-server/pom.xml
@@ -25,4 +25,36 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>ewm.StatsApplication</mainClass>
+                    <layout>JAR</layout>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>ewm.StatsApplication</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/stats-service/stats-server/src/main/java/ewm/StatsApplication.java
+++ b/stats-service/stats-server/src/main/java/ewm/StatsApplication.java
@@ -1,0 +1,12 @@
+package ewm;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class StatsApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(StatsApplication.class, args);
+    }
+
+}

--- a/stats-service/stats-server/src/main/resources/application.properties
+++ b/stats-service/stats-server/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=9090


### PR DESCRIPTION
Добавлена реализация клиента статистики с использованием RestTemplate.
Содержит вызовы 2 эндпоинтов:
- POST /hit
- GET /stats

Кроме того, обновлены докерфайлы и docker-compose.yaml для заглушек main и stats сервисов.